### PR TITLE
Add MakeConnection and Connector

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -2,7 +2,7 @@ use futures::{future, Future, Stream};
 use http::{Method, Request, Uri};
 use hyper::rt;
 use hyper::Body;
-use tower_hyper::Client;
+use tower_hyper::client::Client;
 use tower_service::Service;
 
 fn main() {

--- a/examples/conn_client.rs
+++ b/examples/conn_client.rs
@@ -9,13 +9,14 @@ use tower_buffer::Buffer;
 use tower_hyper::Connect;
 use tower_service::Service;
 // use tower_util::MakeService;
-use tower_hyper::util::MakeService;
+use tower_hyper::util::{MakeService, Connector};
 
 fn main() {
     pretty_env_logger::init();
     rt::run(future::lazy(|| {
         let dst = Destination::try_from_uri(Uri::from_static("http://127.0.0.1:3000")).unwrap();
-        let mut hyper = Connect::new(HttpConnector::new(1), Builder::new());
+        let connector = Connector::new(HttpConnector::new(1));
+        let mut hyper = Connect::new(connector, Builder::new());
 
         hyper
             .make_service(dst)

--- a/examples/conn_client.rs
+++ b/examples/conn_client.rs
@@ -6,7 +6,7 @@ use hyper::rt;
 use hyper::Body;
 use tokio_executor::DefaultExecutor;
 use tower_buffer::Buffer;
-use tower_hyper::Connect;
+use tower_hyper::client::Connect;
 use tower_service::Service;
 // use tower_util::MakeService;
 use tower_hyper::util::{MakeService, Connector};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,3 +1,5 @@
+//! The client portion of `tower-hyper`.
+//!
 //! The client module contains three main utiliteies client, connection
 //! and connect. Connection and Connect are designed to be used together
 //! where as Client is a thicker client designed to be used by itself. There
@@ -10,6 +12,7 @@ mod connection;
 
 pub use self::connect::{Connect, ConnectError};
 pub use self::connection::Connection;
+pub use hyper::client::conn::Builder;
 
 use futures::{Async, Poll};
 use http::{Request, Response};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@
 //! the client portion is done and working. The server side is blocked partially
 //! by hypers use of its own Service and MakeService traits.
 
-mod client;
+pub mod client;
 mod retries;
 pub mod util;
-
-pub use self::client::{Client, Connect, ConnectError, Connection};

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,9 +8,13 @@ use tower_service::Service;
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```
+/// # use tower_hyper::util::Connector;
+/// # use tower_hyper::client::{Connect, Builder};
+/// # use hyper::client::HttpConnector;
 /// let connector = Connector::new(HttpConnector::new(1));
 /// let mut hyper = Connect::new(connector, Builder::new());
+/// # let hyper: Connect<hyper::client::connect::Destination, hyper::Body, Connector<HttpConnector>> = hyper;
 /// ```
 pub struct Connector<C> {
     inner: C,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,49 +1,57 @@
-use futures::{Future, Poll};
+use futures::{Future, Poll, Async, try_ready};
 use hyper::client::connect::{Connect, Destination};
-use tokio_io::{AsyncRead, AsyncWrite};
 use tower_direct_service::DirectService;
 use tower_service::Service;
 
-/// The ConnectService trait is used to create transports
-///
-/// The goal of this service is to allow composable methods to creating
-/// `AsyncRead + AsyncWrite` transports. This could mean creating a TLS
-/// based connection or using some other method to authenticate the connection.
-pub trait ConnectService<A> {
-    type Response: AsyncRead + AsyncWrite;
-    type Error;
-    type Future: Future<Item = Self::Response, Error = Self::Error>;
-
-    fn connect(&mut self, target: A) -> Self::Future;
+pub struct Connector<C> {
+    inner: C,
 }
 
-// Here for references
-// impl<A, C> ConnectService<A> for C
-// where
-//     C: Service<A>,
-//     C::Response: AsyncRead + AsyncWrite,
-// {
-//     type Response = C::Response;
-//     type Error = C::Error;
-//     type Future = C::Future;
-
-//     fn connect(&mut self, target: A) -> Self::Future {
-//         self.call(target)
-//     }
-// }
-
-impl<C> ConnectService<Destination> for C
+pub struct ConnectorFuture<C>
 where
     C: Connect,
-    C::Future: 'static,
+{
+    inner: C::Future,
+}
+
+impl<C> Connector<C>
+where
+    C: Connect,
+{
+    pub fn new(inner: C) -> Self {
+        Self { inner }
+    }
+}
+
+impl<C> Service<Destination> for Connector<C>
+where
+    C: Connect,
 {
     type Response = C::Transport;
     type Error = C::Error;
-    type Future = Box<Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
+    type Future = ConnectorFuture<C>;
 
-    fn connect(&mut self, req: Destination) -> Self::Future {
-        let fut = <Self as Connect>::connect(self, req).map(|(transport, _)| transport);
-        Box::new(fut)
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Ok(().into())
+    }
+
+    fn call(&mut self, target: Destination) -> Self::Future {
+        let fut = self.inner.connect(target);
+        ConnectorFuture { inner: fut }
+    }
+}
+
+impl<C> Future for ConnectorFuture<C>
+where
+    C: Connect,
+{
+    type Item = C::Transport;
+    type Error = C::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let (transport, _) = try_ready!(self.inner.poll());
+
+        Ok(Async::Ready(transport))
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,10 +3,21 @@ use hyper::client::connect::{Connect, Destination};
 use tower_direct_service::DirectService;
 use tower_service::Service;
 
+/// A bridge between `hyper::client::connect::Connect` types
+/// and `tower_util::MakeConnection`.
+///
+/// # Example
+///
+/// ```no_run
+/// let connector = Connector::new(HttpConnector::new(1));
+/// let mut hyper = Connect::new(connector, Builder::new());
+/// ```
 pub struct Connector<C> {
     inner: C,
 }
 
+/// The future that resolves to the eventual inner transport
+/// as built by `hyper::client::connect::Connect`.
 pub struct ConnectorFuture<C>
 where
     C: Connect,
@@ -18,6 +29,7 @@ impl<C> Connector<C>
 where
     C: Connect,
 {
+    /// Construct a new connector from a `hyper::client::connect::Connect`
     pub fn new(inner: C) -> Self {
         Self { inner }
     }


### PR DESCRIPTION
This change adds the new MakeConnection trait alias and adds a new
concrete Connector type to bridge the gap between hyper Connectors and MakeConnection.