### PR TITLE
Add compatibility with tower_http::Body types

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,30 +1,36 @@
-use futures::{future, Future, Stream};
+use futures::{future, Future};
 use http::{Method, Request, Uri};
 use hyper::rt;
-use hyper::Body;
+use tokio_buf::util::BufStreamExt;
+use tower_http::BodyExt;
 use tower_hyper::client::Client;
 use tower_service::Service;
 
 fn main() {
     rt::run(future::lazy(|| {
         let uri = "http://httpbin.org/ip".parse::<Uri>().unwrap();
-        let mut svc = Client::new(hyper::Client::new());
+        let mut svc = Client::new();
 
         let request = Request::builder()
             .uri(uri)
             .method(Method::GET)
-            .body(Body::empty())
+            .body(Vec::new())
             .unwrap();
 
         svc.call(request)
+            .map_err(|err| eprintln!("Request Error: {}", err))
             .and_then(|response| {
                 println!("Response Status: {:?}", response.status());
-                response.into_body().concat2()
+                response
+                    .into_body()
+                    .into_buf_stream()
+                    .collect::<Vec<u8>>()
+                    .map(|v| String::from_utf8(v).unwrap())
+                    .map_err(|e| eprintln!("Body Error: {:?}", e))
             })
             .and_then(|body| {
-                println!("Response Body: {:?}", body);
+                println!("Response Body: {}", body);
                 Ok(())
             })
-            .map_err(|err| eprintln!("Request Error: {}", err))
     }));
 }

--- a/examples/conn_client.rs
+++ b/examples/conn_client.rs
@@ -1,11 +1,12 @@
-use futures::{future, Future, Stream};
+use futures::{future, Future};
 use http::{Request, Uri};
 use hyper::client::conn::Builder;
 use hyper::client::connect::{Destination, HttpConnector};
 use hyper::rt;
-use hyper::Body;
+use tokio_buf::util::BufStreamExt;
 use tower::MakeService;
 use tower_buffer::Buffer;
+use tower_http::BodyExt;
 use tower_hyper::client::Connect;
 use tower_hyper::util::Connector;
 use tower_service::Service;
@@ -22,17 +23,19 @@ fn main() {
             .map_err(|err| eprintln!("Connect Error {:?}", err))
             .and_then(|conn| Buffer::new(conn, 1).map_err(|_| panic!("Unable to spawn!")))
             .and_then(|mut conn| {
-                conn.call(Request::new(Body::empty()))
+                conn.call(Request::new(Vec::new())) // Empty request, but `Vec<u8>` implements `tower_http::Body`
                     .map_err(|e| eprintln!("Call Error: {}", e))
                     .and_then(|response| {
                         println!("Response Status: {:?}", response.status());
                         response
                             .into_body()
-                            .concat2()
-                            .map_err(|e| eprintln!("Body Error: {}", e))
+                            .into_buf_stream()
+                            .collect::<Vec<u8>>()
+                            .map(|v| String::from_utf8(v).unwrap())
+                            .map_err(|e| eprintln!("Body Error: {:?}", e))
                     })
                     .and_then(|body| {
-                        println!("Response Body: {:?}", body);
+                        println!("Response Body: {}", body);
                         Ok(())
                     })
             })

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -40,7 +40,7 @@ struct Svc;
 impl<B> Service<Request<B>> for Svc
     where B: tower_http::Body
 {
-    type Response = Response<LiftBody<Body>>;
+    type Response = Response<Vec<u8>>;
     type Error = hyper::Error;
     type Future = future::FutureResult<Self::Response, Self::Error>;
 
@@ -49,7 +49,8 @@ impl<B> Service<Request<B>> for Svc
     }
 
     fn call(&mut self, _req: Request<B>) -> Self::Future {
-        let body = LiftBody::new(Body::from("Hello World!"));
+        // let body = LiftBody::new(Body::from("Hello World!"));
+        let body = b"Hello World!".to_vec();
         let res = Response::new(body);
         future::ok(res)
     }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -37,7 +37,9 @@ fn main() {
 }
 
 struct Svc;
-impl Service<Request<LiftBody<Body>>> for Svc {
+impl<B> Service<Request<B>> for Svc
+    where B: tower_http::Body
+{
     type Response = Response<LiftBody<Body>>;
     type Error = hyper::Error;
     type Future = future::FutureResult<Self::Response, Self::Error>;
@@ -46,7 +48,7 @@ impl Service<Request<LiftBody<Body>>> for Svc {
         Ok(().into())
     }
 
-    fn call(&mut self, _req: Request<LiftBody<Body>>) -> Self::Future {
+    fn call(&mut self, _req: Request<B>) -> Self::Future {
         let body = LiftBody::new(Body::from("Hello World!"));
         let res = Response::new(body);
         future::ok(res)

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -37,7 +37,7 @@ fn main() {
 }
 
 struct Svc;
-impl Service<Request<Body>> for Svc {
+impl Service<Request<LiftBody<Body>>> for Svc {
     type Response = Response<LiftBody<Body>>;
     type Error = hyper::Error;
     type Future = future::FutureResult<Self::Response, Self::Error>;
@@ -46,7 +46,7 @@ impl Service<Request<Body>> for Svc {
         Ok(().into())
     }
 
-    fn call(&mut self, _req: Request<Body>) -> Self::Future {
+    fn call(&mut self, _req: Request<LiftBody<Body>>) -> Self::Future {
         let body = LiftBody::new(Body::from("Hello World!"));
         let res = Response::new(body);
         future::ok(res)

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,7 +1,6 @@
 use futures::{future, Future, Poll, Stream};
-use hyper::{Body, Request, Response};
+use hyper::{Request, Response};
 use tokio_tcp::TcpListener;
-use tower_hyper::body::LiftBody;
 use tower_hyper::server::Server;
 use tower_service::Service;
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -39,7 +39,7 @@ struct Svc;
 impl<B> Service<Request<B>> for Svc
     where B: tower_http::Body
 {
-    type Response = Response<Vec<u8>>;
+    type Response = Response<B>;
     type Error = hyper::Error;
     type Future = future::FutureResult<Self::Response, Self::Error>;
 
@@ -47,9 +47,8 @@ impl<B> Service<Request<B>> for Svc
         Ok(().into())
     }
 
-    fn call(&mut self, _req: Request<B>) -> Self::Future {
-        // let body = LiftBody::new(Body::from("Hello World!"));
-        let body = b"Hello World!".to_vec();
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let body = req.into_body();
         let res = Response::new(body);
         future::ok(res)
     }

--- a/src/body.rs
+++ b/src/body.rs
@@ -3,6 +3,7 @@
 use futures::Poll;
 use hyper::body::Payload;
 use tokio_buf::BufStream;
+use tower_http::Body as HttpBody;
 
 /// Lifts a body to support `Payload` and `BufStream`
 #[derive(Debug)]
@@ -30,5 +31,24 @@ impl<T: Payload> BufStream for LiftBody<T> {
 
     fn poll_buf(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         self.inner.poll_data()
+    }
+}
+
+impl<T> Payload for LiftBody<T>
+    where T: HttpBody + Send + 'static,
+          T::Item: Send,
+          T::Error: std::error::Error + Send + Sync,
+{
+    type Data = T::Item;
+    type Error = T::Error;
+    fn poll_data(&mut self) -> Poll<Option<Self::Data>, Self::Error> {
+        self.inner.poll_buf()
+    }
+
+    fn poll_trailers(&mut self) -> Poll<Option<hyper::HeaderMap>, Self::Error> {
+        self.inner.poll_trailers()
+    }
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
     }
 }

--- a/src/body.rs
+++ b/src/body.rs
@@ -44,7 +44,7 @@ impl<T: Payload> HttpBody for LiftBody<T> {
 impl<T> Payload for LiftBody<T>
     where T: HttpBody + Send + 'static,
           T::Item: Send,
-          T::Error: std::error::Error + Send + Sync,
+          T::Error: Into<Box<std::error::Error + Send + Sync>>,
 {
     type Data = T::Item;
     type Error = T::Error;

--- a/src/body.rs
+++ b/src/body.rs
@@ -2,7 +2,6 @@
 
 use futures::Poll;
 use hyper::body::Payload;
-use tokio_buf::BufStream;
 use tower_http::Body as HttpBody;
 
 /// Lifts a body to support `Payload` and `BufStream`
@@ -25,12 +24,20 @@ impl<T: Payload> LiftBody<T> {
     }
 }
 
-impl<T: Payload> BufStream for LiftBody<T> {
+impl<T: Payload> HttpBody for LiftBody<T> {
     type Item = <T as Payload>::Data;
     type Error = <T as Payload>::Error;
 
     fn poll_buf(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         self.inner.poll_data()
+    }
+
+    fn poll_trailers(&mut self) -> Poll<Option<hyper::HeaderMap>, Self::Error> {
+        self.inner.poll_trailers()
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
     }
 }
 

--- a/src/body.rs
+++ b/src/body.rs
@@ -44,7 +44,7 @@ impl<T: Payload> HttpBody for LiftBody<T> {
 impl<T> Payload for LiftBody<T>
     where T: HttpBody + Send + 'static,
           T::Item: Send,
-          T::Error: Into<Box<std::error::Error + Send + Sync>>,
+          T::Error: Into<crate::Error>
 {
     type Data = T::Item;
     type Error = T::Error;

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -83,8 +83,9 @@ where
 impl<A, B, C> Service<A> for Connect<A, B, C>
 where
     C: MakeConnection<A> + 'static,
-    B: HttpBody,
-    LiftBody<B>: hyper::body::Payload,
+    B: HttpBody + Send + 'static,
+    B::Item: Send,
+    B::Error: Into<crate::Error>,
     C::Connection: Send + 'static,
 {
     type Response = Connection<B>;
@@ -112,8 +113,9 @@ where
 impl<A, B, C> Future for ConnectFuture<A, B, C>
 where
     C: MakeConnection<A>,
-    B: HttpBody,
-    LiftBody<B>: hyper::body::Payload,
+    B: HttpBody + Send + 'static,
+    B::Item: Send,
+    B::Error: Into<crate::Error>,
     C::Connection: Send + 'static,
 {
     type Item = Connection<B>;

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -1,7 +1,7 @@
 use super::Connection;
+use crate::body::LiftBody;
 use futures::future::Executor;
 use futures::{try_ready, Async, Future, Poll};
-use hyper::body::Payload;
 use hyper::client::conn::{Builder, Handshake};
 use hyper::Error;
 use log::error;
@@ -10,6 +10,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use tokio_executor::DefaultExecutor;
 use tower::MakeConnection;
+use tower_http::Body as HttpBody;
 use tower_service::Service;
 
 /// Creates a `hyper` connection
@@ -28,7 +29,7 @@ pub struct Connect<A, B, C> {
 /// or error
 pub struct ConnectFuture<A, B, C>
 where
-    B: Payload,
+    B: HttpBody,
     C: MakeConnection<A>,
 {
     state: State<A, B, C>,
@@ -37,11 +38,11 @@ where
 
 enum State<A, B, C>
 where
-    B: Payload,
+    B: HttpBody,
     C: MakeConnection<A>,
 {
     Connect(C::Future),
-    Handshake(Handshake<C::Connection, B>),
+    Handshake(Handshake<C::Connection, LiftBody<B>>),
 }
 
 /// The error produced from creating a connection
@@ -61,7 +62,7 @@ pub enum ConnectError<T> {
 impl<A, B, C> Connect<A, B, C>
 where
     C: MakeConnection<A>,
-    B: Payload,
+    B: HttpBody,
     C::Connection: Send + 'static,
 {
     /// Create a new `Connect`.
@@ -82,7 +83,8 @@ where
 impl<A, B, C> Service<A> for Connect<A, B, C>
 where
     C: MakeConnection<A> + 'static,
-    B: Payload + 'static,
+    B: HttpBody + 'static,
+    LiftBody<B>: hyper::body::Payload,
     C::Connection: Send + 'static,
 {
     type Response = Connection<B>;
@@ -93,7 +95,7 @@ where
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         self.inner
             .poll_ready()
-            .map_err(|e| ConnectError::Connect(e))
+            .map_err(ConnectError::Connect)
     }
 
     /// Obtains a Connection on a single plaintext h2 connection to a remote.
@@ -110,7 +112,8 @@ where
 impl<A, B, C> Future for ConnectFuture<A, B, C>
 where
     C: MakeConnection<A>,
-    B: Payload,
+    B: HttpBody,
+    LiftBody<B>: hyper::body::Payload,
     C::Connection: Send + 'static,
 {
     type Item = Connection<B>;
@@ -146,7 +149,7 @@ where
 impl<A, B, C> fmt::Debug for ConnectFuture<A, B, C>
 where
     C: MakeConnection<A>,
-    B: Payload,
+    B: HttpBody,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("ConnectFuture")

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -83,7 +83,7 @@ where
 impl<A, B, C> Service<A> for Connect<A, B, C>
 where
     C: MakeConnection<A> + 'static,
-    B: HttpBody + 'static,
+    B: HttpBody,
     LiftBody<B>: hyper::body::Payload,
     C::Connection: Send + 'static,
 {

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -1,9 +1,11 @@
 use crate::body::LiftBody;
 use futures::{Future, Poll};
 use http::{Request, Response};
-use hyper::body::Payload;
 use hyper::client::conn;
+use tower_http::Body as HttpBody;
 use tower_service::Service;
+
+use std::fmt;
 
 /// The connection provided from `hyper`
 ///
@@ -13,52 +15,60 @@ use tower_service::Service;
 #[derive(Debug)]
 pub struct Connection<B>
 where
-    B: Payload,
+    B: HttpBody,
 {
-    sender: conn::SendRequest<B>,
+    sender: conn::SendRequest<LiftBody<B>>,
 }
 
 impl<B> Connection<B>
 where
-    B: Payload,
+    B: HttpBody,
 {
-    pub(super) fn new(sender: conn::SendRequest<B>) -> Self {
+    pub(super) fn new(sender: conn::SendRequest<LiftBody<B>>) -> Self {
         Connection { sender }
     }
 }
 
 impl<B> Service<Request<B>> for Connection<B>
 where
-    B: Payload,
-{
-    type Response = Response<hyper::Body>;
-    type Error = hyper::Error;
-    type Future = conn::ResponseFuture;
-
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.sender.poll_ready()
-    }
-
-    fn call(&mut self, req: Request<B>) -> Self::Future {
-        self.sender.send_request(req)
-    }
-}
-
-impl<B> Service<Request<B>> for Connection<LiftBody<B>>
-where
-    LiftBody<B>: Payload,
+    LiftBody<B>: hyper::body::Payload,
+    B: HttpBody,
 {
     type Response = Response<LiftBody<hyper::Body>>;
     type Error = hyper::Error;
-    type Future = Box<Future<Item=Self::Response, Error=Self::Error> + Send>;
+    type Future = LiftResponseFuture<conn::ResponseFuture>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         self.sender.poll_ready()
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
-        Box::new(self.sender
-                      .send_request(req.map(LiftBody::new))
-                      .map(|resp| resp.map(LiftBody::new)))
+        LiftResponseFuture(self.sender.send_request(req.map(LiftBody::new)))
+    }
+}
+
+/// Lift a hyper ResponseFuture to one which returns LiftBody
+pub struct LiftResponseFuture<F>(pub(crate) F);
+
+impl<F> Future for LiftResponseFuture<F>
+    where F: Future<Item=Response<hyper::Body>, Error=hyper::Error>,
+{
+    type Item = Response<LiftBody<hyper::Body>>;
+    type Error = hyper::Error;
+
+    #[inline]
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.0.poll() {
+            Ok(futures::Async::Ready(body)) => Ok(futures::Async::Ready(body.map(LiftBody::new))),
+            Ok(futures::Async::NotReady) => Ok(futures::Async::NotReady),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+
+impl<F: fmt::Debug> fmt::Debug for LiftResponseFuture<F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "LiftResponseFuture<{:?}>", self.0)
     }
 }

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -31,8 +31,9 @@ where
 
 impl<B> Service<Request<B>> for Connection<B>
 where
-    LiftBody<B>: hyper::body::Payload,
-    B: HttpBody,
+    B: HttpBody + Send + 'static,
+    B::Item: Send,
+    B::Error: Into<Box<std::error::Error + Send + Sync>>,
 {
     type Response = Response<LiftBody<hyper::Body>>;
     type Error = hyper::Error;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -64,8 +64,13 @@ impl<C, B> Client<C, B> {
     ///
     /// The existing default is:
     ///```
+    ///   use http::Request;
+    ///   use tower_hyper::client::Client;
+    ///   use tower_service::Service;
+    ///
     ///   let inner = hyper::Client::builder().build_http();
-    ///   Client::with_client(inner)
+    ///   let mut client = Client::with_client(inner);
+    ///   let _ = client.call(Request::new(vec![0, 1, 2]));
     /// ````
     /// which returns a `Client<HttpConnector, B>` for any B: `HttpBody`.
     pub fn with_client(inner: hyper::Client<C, LiftBody<B>>) -> Self {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -36,7 +36,7 @@ impl<B> Default for Client<HttpConnector, B>
     where
         B: HttpBody + Send + 'static,
         B::Item: Send,
-        B::Error: Into<Box<std::error::Error + Send + Sync>>,
+        B::Error: Into<crate::Error>,
 {
     fn default() -> Self {
         Self::new()
@@ -47,7 +47,7 @@ impl<B> Client<HttpConnector, B>
     where
         B: HttpBody + Send + 'static,
         B::Item: Send,
-        B::Error: Into<Box<std::error::Error + Send + Sync>>,
+        B::Error: Into<crate::Error>,
 
 {
     /// Create a new client, using the default hyper settings
@@ -85,11 +85,11 @@ where
     C::Future: 'static,
     B: HttpBody + Send + 'static,
     B::Item: Send,
-    B::Error: Into<Box<std::error::Error + Send + Sync>>,
+    B::Error: Into<crate::Error>,
 {
     type Response = Response<LiftBody<Body>>;
     type Error = hyper::Error;
-    type Future = connection::LiftResponseFuture<ResponseFuture>;
+    type Future = connection::ResponseFuture<ResponseFuture>;
 
     /// Poll to see if the service is ready, since `hyper::Client`
     /// already handles this internally this will always return ready
@@ -100,6 +100,6 @@ where
     /// Send the sepcficied request to the inner `hyper::Client`
     fn call(&mut self, req: Request<B>) -> Self::Future {
         let fut = self.inner.request(req.map(LiftBody::new));
-        connection::LiftResponseFuture(fut)
+        connection::ResponseFuture(fut)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,8 @@ pub mod retry;
 pub mod server;
 /// Util for working with hyper and tower
 pub mod util;
+
+
+// Known bug in rustc: https://github.com/rust-lang/rust/issues/18290
+#[allow(dead_code)]
+pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -114,8 +114,7 @@ where
             .inner
             .call(request.map(LiftBody::new))
             .map(|r| r.map(LiftBody::new))
-            .map_err(|e| {
-                eprintln!("{:?}", e.into());
+            .map_err(|_e| {
                 unimplemented!()
             });
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,12 +2,13 @@
 
 use crate::body::LiftBody;
 use futures::Future;
-use hyper::service::Service as HyperService;
 use hyper::Body;
+use hyper::service::Service as HyperService;
 use hyper::{Request, Response};
 use tokio_io::{AsyncRead, AsyncWrite};
 use tower::MakeService;
 use tower_http::HttpService;
+use tower_http::Body as HttpBody;
 use tower_service::Service;
 
 pub use hyper::server::conn::Http;
@@ -18,21 +19,28 @@ type Error = Box<dyn std::error::Error + Send + Sync>;
 
 /// Server implemenation for hyper
 #[derive(Debug)]
-pub struct Server<S> {
+pub struct Server<S, B> {
     maker: S,
+    _marker: std::marker::PhantomData<B>,
 }
 
-impl<S> Server<S>
+impl<S, B> Server<S, B>
 where
-    S: MakeService<(), Request<Body>, Response = Response<LiftBody<Body>>> + Send + 'static,
+    B: HttpBody + Send + 'static,
+    B::Item: Send,
+    B::Error: std::error::Error + Send + Sync,
+    S: MakeService<(), Request<LiftBody<Body>>, Response = Response<B>> + Send + 'static,
     S::Error: Into<Error> + 'static,
     S::Future: Send + 'static,
-    S::Service: Service<Request<Body>> + Send + 'static,
-    <S::Service as Service<Request<Body>>>::Future: Send + 'static,
+    S::Service: Service<Request<LiftBody<Body>>> + Send + 'static,
+    <S::Service as Service<Request<LiftBody<Body>>>>::Future: Send + 'static,
 {
     /// Create a new server from a `MakeService`
     pub fn new(maker: S) -> Self {
-        Server { maker }
+        Server {
+            maker,
+            _marker: std::marker::PhantomData
+        }
     }
 
     /// Serve the `io` stream via default hyper http settings
@@ -62,31 +70,41 @@ where
             .map_err(|_| unimplemented!())
             .and_then(move |service| {
                 let service = Lift::new(service);
-                http.serve_connection(io, service)
+                http.serve_connection::<Lift<S::Service, B>, I, LiftBody<B>>(io, service)
             });
 
         Box::new(fut)
     }
 }
 
-struct Lift<T> {
+struct Lift<T, B> {
     inner: T,
+    _marker: std::marker::PhantomData<B>,
 }
 
-impl<T> Lift<T> {
+impl<T, B> Lift<T, B> {
     pub fn new(inner: T) -> Self {
-        Lift { inner }
+        Lift { 
+            inner,
+            _marker: std::marker::PhantomData,
+        }
     }
 }
 
-impl<T> HyperService for Lift<T>
+// Lift takes in a service on `LiftBody<Body> -> B` (both implement http::Body)
+// and returns a `hyper::Service` which instead takes in `Request<Body>`
+// and outputs `Response<LiftBody<B>>` (which both implement payload).
+impl<T, B> HyperService for Lift<T, B>
 where
-    T: HttpService<Body, ResponseBody = LiftBody<Body>> + Send + 'static,
+    B: HttpBody + Send + 'static,
+    B::Item: Send,
+    B::Error: std::error::Error + Send + Sync,
+    T: HttpService<LiftBody<Body>, ResponseBody = B> + Send + 'static,
     T::Error: Into<Error> + 'static,
     T::Future: Send + 'static,
 {
     type ReqBody = Body;
-    type ResBody = Body;
+    type ResBody = LiftBody<B>;
     type Error = hyper::Error;
     // type Future = T::Future;
     type Future = Box<Future<Item = Response<Self::ResBody>, Error = Self::Error> + Send + 'static>;
@@ -94,9 +112,12 @@ where
     fn call(&mut self, request: Request<Self::ReqBody>) -> Self::Future {
         let fut = self
             .inner
-            .call(request)
-            .map(|r| r.map(LiftBody::into_inner))
-            .map_err(|_| unimplemented!());
+            .call(request.map(LiftBody::new))
+            .map(|r| r.map(LiftBody::new))
+            .map_err(|e| {
+                eprintln!("{:?}", e.into());
+                unimplemented!()
+            });
 
         Box::new(fut)
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -28,7 +28,7 @@ impl<S, B> Server<S, B>
 where
     B: HttpBody + Send + 'static,
     B::Item: Send,
-    B::Error: std::error::Error + Send + Sync,
+    B::Error: Into<Box<std::error::Error + Send + Sync>>,
     S: MakeService<(), Request<LiftBody<Body>>, Response = Response<B>> + Send + 'static,
     S::Error: Into<Error> + 'static,
     S::Future: Send + 'static,
@@ -98,7 +98,7 @@ impl<T, B> HyperService for Lift<T, B>
 where
     B: HttpBody + Send + 'static,
     B::Item: Send,
-    B::Error: std::error::Error + Send + Sync,
+    B::Error: Into<Box<std::error::Error + Send + Sync>>,
     T: HttpService<LiftBody<Body>, ResponseBody = B> + Send + 'static,
     T::Error: Into<Error> + 'static,
     T::Future: Send + 'static,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,10 +13,6 @@ use tower_service::Service;
 
 pub use hyper::server::conn::Http;
 
-// Known bug in rustc: https://github.com/rust-lang/rust/issues/18290
-#[allow(dead_code)]
-type Error = Box<dyn std::error::Error + Send + Sync>;
-
 /// Server implemenation for hyper
 #[derive(Debug)]
 pub struct Server<S, B> {
@@ -28,9 +24,9 @@ impl<S, B> Server<S, B>
 where
     B: HttpBody + Send + 'static,
     B::Item: Send,
-    B::Error: Into<Box<std::error::Error + Send + Sync>>,
+    B::Error: Into<crate::Error>,
     S: MakeService<(), Request<LiftBody<Body>>, Response = Response<B>> + Send + 'static,
-    S::Error: Into<Error> + 'static,
+    S::Error: Into<crate::Error> + 'static,
     S::Future: Send + 'static,
     S::Service: Service<Request<LiftBody<Body>>> + Send + 'static,
     <S::Service as Service<Request<LiftBody<Body>>>>::Future: Send + 'static,
@@ -98,9 +94,9 @@ impl<T, B> HyperService for Lift<T, B>
 where
     B: HttpBody + Send + 'static,
     B::Item: Send,
-    B::Error: Into<Box<std::error::Error + Send + Sync>>,
+    B::Error: Into<crate::Error>,
     T: HttpService<LiftBody<Body>, ResponseBody = B> + Send + 'static,
-    T::Error: Into<Error> + 'static,
+    T::Error: Into<crate::Error> + 'static,
     T::Future: Send + 'static,
 {
     type ReqBody = Body;

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,7 +13,7 @@ use tower_service::Service;
 /// # use hyper::client::HttpConnector;
 /// let connector = Connector::new(HttpConnector::new(1));
 /// let mut hyper = Connect::new(connector, Builder::new());
-/// # let hyper: Connect<hyper::client::connect::Destination, hyper::Body, Connector<HttpConnector>> = hyper;
+/// # let hyper: Connect<hyper::client::connect::Destination, Vec<u8>, Connector<HttpConnector>> = hyper;
 /// ```
 #[derive(Debug)]
 pub struct Connector<C> {


### PR DESCRIPTION
This is a first pass at fixing #19. 

The basic idea was sketched out with @LucioFranco, but I went off on a different path.

What this does is makes `hyper::body::Payload` and `tower_http::Body` fairly interchangeable, by wrapping either one in `LiftBody`. (One direction is already done since `LiftBody` implements `BufStream` which implements `Body`).

I made a few tweaks to the client and (breaking) changes to the server to support this. The result is that the `tower_hyper::client::Connection` can additionally accept any request `B` such that `LiftBody<B>: Payload`.

Services passed to the `tower_hyper::server::Server` need to instead take `LiftBody<Body>` (which is better, since now any blanket request impl taking `Body` works, as in the example), but can return any `B: Body`. So the return types can be more flexible. 
