### PR TITLE
polish server implementation

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -56,7 +56,7 @@ struct LiftService<T, B> {
 #[derive(Debug)]
 struct LiftServiceFuture<F, B> {
     inner: F,
-    _pd: PhantomData<fn() -> B>,
+    _pd: PhantomData<B>,
 }
 
 impl<S, B> Server<S, B>


### PR DESCRIPTION
* add the implementation of `HyperService::poll_ready` to poll the readiness of inner service
* introduce the wrapper type `LiftServiceFuture` to avoid heap allocation per `HyperService::call`