### PR TITLE
Update to use `hyper::Body`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ http = "0.1"
 http-body = "0.1"
 http-connection = { git = "https://github.com/hyperium/http-connection" }
 log = "0.4"
-hyper = "0.12.28"
+hyper = "0.12.29"
 tokio-io = "0.1"
 tokio-buf = "0.1"
 tokio-executor = "0.1"

--- a/src/body.rs
+++ b/src/body.rs
@@ -4,11 +4,7 @@ use futures::Poll;
 use http_body::Body as HttpBody;
 use hyper::body::Payload;
 
-/// Specialized Body that takes a `hyper::Body` and implements `tower_http::Body`.
-#[derive(Debug)]
-pub struct Body {
-    inner: hyper::Body,
-}
+pub use hyper::Body;
 
 /// Lifts a body to support `Payload`
 #[derive(Debug)]
@@ -38,53 +34,6 @@ where
     fn poll_trailers(&mut self) -> Poll<Option<hyper::HeaderMap>, Self::Error> {
         self.inner.poll_trailers()
     }
-    fn is_end_stream(&self) -> bool {
-        self.inner.is_end_stream()
-    }
-}
-
-impl From<hyper::Body> for Body {
-    fn from(inner: hyper::Body) -> Self {
-        Body { inner }
-    }
-}
-
-impl Body {
-    /// Get the inner wrapped `hyper::Body`.
-    pub fn into_inner(self) -> hyper::Body {
-        self.inner
-    }
-}
-
-impl HttpBody for Body {
-    type Data = hyper::Chunk;
-    type Error = hyper::Error;
-
-    fn poll_data(&mut self) -> Poll<Option<Self::Data>, Self::Error> {
-        self.inner.poll_data()
-    }
-
-    fn poll_trailers(&mut self) -> Poll<Option<hyper::HeaderMap>, Self::Error> {
-        self.inner.poll_trailers()
-    }
-
-    fn is_end_stream(&self) -> bool {
-        self.inner.is_end_stream()
-    }
-}
-
-impl Payload for Body {
-    type Data = hyper::Chunk;
-    type Error = hyper::Error;
-
-    fn poll_data(&mut self) -> Poll<Option<Self::Data>, Self::Error> {
-        self.inner.poll_data()
-    }
-
-    fn poll_trailers(&mut self) -> Poll<Option<hyper::HeaderMap>, Self::Error> {
-        self.inner.poll_trailers()
-    }
-
     fn is_end_stream(&self) -> bool {
         self.inner.is_end_stream()
     }


### PR DESCRIPTION
Now that `hyper::Body` implements `http_body::Body` we can use this instead of our own version.

Closes #31 
Closes #32