### PR TITLE
Introduce client::Background

### DIFF
--- a/src/client/background.rs
+++ b/src/client/background.rs
@@ -1,0 +1,56 @@
+use futures::{Future, Poll};
+use hyper::body::Payload;
+use hyper::client::conn::Connection as HyperConnection;
+use std::fmt::{self, Debug};
+use tokio_io::{AsyncRead, AsyncWrite};
+
+use log::error;
+
+/// Background task for a client connection.
+///
+/// This type is not used directly by a user of this library,
+/// but it can show up in trait bounds of generic types.
+pub struct Background<T, B>
+where
+    T: AsyncRead + AsyncWrite + Send + 'static,
+    B: Payload,
+{
+    connection: HyperConnection<T, B>,
+}
+
+impl<T, B> Debug for Background<T, B>
+where
+    T: Debug + AsyncRead + AsyncWrite + Send + 'static,
+    B: Payload,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Background")
+            .field("connection", &self.connection)
+            .finish()
+    }
+}
+
+impl<T, B> Background<T, B>
+where
+    T: AsyncRead + AsyncWrite + Send + 'static,
+    B: Payload,
+{
+    pub(super) fn new(connection: HyperConnection<T, B>) -> Self {
+        Background { connection }
+    }
+}
+
+impl<T, B> Future for Background<T, B>
+where
+    T: AsyncRead + AsyncWrite + Send + 'static,
+    B: Payload,
+{
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<(), ()> {
+        self.connection.poll().map_err(|e| {
+            error!("error with hyper: {}", e);
+        })
+    }
+}

--- a/src/client/background.rs
+++ b/src/client/background.rs
@@ -1,10 +1,9 @@
 use futures::{Future, Poll};
 use hyper::body::Payload;
 use hyper::client::conn::Connection as HyperConnection;
+use log::error;
 use std::fmt::{self, Debug};
 use tokio_io::{AsyncRead, AsyncWrite};
-
-use log::error;
 
 /// Background task for a client connection.
 ///
@@ -16,18 +15,6 @@ where
     B: Payload,
 {
     connection: HyperConnection<T, B>,
-}
-
-impl<T, B> Debug for Background<T, B>
-where
-    T: Debug + AsyncRead + AsyncWrite + Send + 'static,
-    B: Payload,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Background")
-            .field("connection", &self.connection)
-            .finish()
-    }
 }
 
 impl<T, B> Background<T, B>
@@ -52,5 +39,17 @@ where
         self.connection.poll().map_err(|e| {
             error!("error with hyper: {}", e);
         })
+    }
+}
+
+impl<T, B> Debug for Background<T, B>
+where
+    T: Debug + AsyncRead + AsyncWrite + Send + 'static,
+    B: Payload,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Background")
+            .field("connection", &self.connection)
+            .finish()
     }
 }

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -27,7 +27,7 @@ pub struct Connect<A, B, C, E> {
 }
 
 /// Executor that will spawn the background connection task.
-pub trait ConnectExecutor<T, B>: TypedExecutor<Background<T, LiftBody<B>>>
+pub trait ConnectExecutor<T, B>: TypedExecutor<Background<T, B>>
 where
     T: AsyncRead + AsyncWrite + Send + 'static,
     B: HttpBody + Send + 'static,
@@ -77,7 +77,7 @@ where
     B: HttpBody + Send + 'static,
     B::Data: Send,
     B::Error: Into<crate::Error>,
-    E: TypedExecutor<Background<T, LiftBody<B>>>,
+    E: TypedExecutor<Background<T, B>>,
 {
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -25,10 +25,12 @@
 //! [`Client`]: ./struct.Client.html
 //! [`hyper::Client`]: ../../hyper/struct.Client.html
 
+mod background;
 mod connect;
 mod connection;
 mod future;
 
+pub use self::background::Background;
 pub use self::connect::{Connect, ConnectError};
 pub use self::connection::Connection;
 use self::future::ResponseFuture;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -31,7 +31,7 @@ mod connection;
 mod future;
 
 pub use self::background::Background;
-pub use self::connect::{Connect, ConnectError};
+pub use self::connect::{Connect, ConnectError, ConnectExecutor};
 pub use self::connection::Connection;
 use self::future::ResponseFuture;
 pub use hyper::client::conn::Builder;


### PR DESCRIPTION
A public named type for the background task future, needed to make the signature of the `Service` trait implementation of `Connect` usable with generic executor types. ~~Replaces `ConnectExecutor`~~ The `ConnectExecutor` alias trait uses this type as the parameter for its `TypedExecutor` prerequisite and is made public.

Fixes #44