### PR TITLE
Make client::ResponseFuture public

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -33,7 +33,7 @@ mod future;
 pub use self::background::Background;
 pub use self::connect::{Connect, ConnectError, ConnectExecutor};
 pub use self::connection::Connection;
-use self::future::ResponseFuture;
+pub use self::future::ResponseFuture;
 pub use hyper::client::conn::Builder;
 
 use crate::body::{Body, LiftBody};


### PR DESCRIPTION
The type is already a part of the public API anonymously, as it is returned by the `Service` impls of client connection objects. This change makes the type usable by name.