### PR TITLE
Make client::ConnectFuture public

### DIFF
--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -36,8 +36,7 @@ where
 {
 }
 
-/// The future thre represents the eventual connection
-/// or error
+/// A future that resolves to the eventual connection or an error.
 pub struct ConnectFuture<A, B, C, E>
 where
     B: HttpBody,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -31,7 +31,7 @@ mod connection;
 mod future;
 
 pub use self::background::Background;
-pub use self::connect::{Connect, ConnectError, ConnectExecutor};
+pub use self::connect::{Connect, ConnectError, ConnectExecutor, ConnectFuture};
 pub use self::connection::Connection;
 use self::future::ResponseFuture;
 pub use hyper::client::conn::Builder;


### PR DESCRIPTION
The future is returned by the `MakeService` impl. Make it public so it can be used explicitly in generic code that uses tower-hyper.