### PR TITLE
More usable type parameter bounds on client::Connect

### DIFF
--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -136,7 +136,7 @@ where
 
 impl<A, B, C, E> Service<A> for Connect<A, B, C, E>
 where
-    C: HttpMakeConnection<A> + 'static,
+    C: HttpMakeConnection<A>,
     B: HttpBody + Send + 'static,
     B::Data: Send,
     B::Error: Into<crate::Error>,

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -85,7 +85,9 @@ where
 impl<A, B, C> Connect<A, B, C, DefaultExecutor>
 where
     C: HttpMakeConnection<A>,
-    B: HttpBody,
+    B: HttpBody + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<crate::Error>,
     C::Connection: Send + 'static,
 {
     /// Create a new `Connect`.
@@ -107,8 +109,11 @@ where
 impl<A, B, C, E> Connect<A, B, C, E>
 where
     C: HttpMakeConnection<A>,
-    B: HttpBody,
+    B: HttpBody + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<crate::Error>,
     C::Connection: Send + 'static,
+    E: ConnectExecutor<C::Connection, B> + Clone,
 {
     /// Create a new `Connect`.
     ///


### PR DESCRIPTION
Harmonize type parameter bounds between the constructors of `client::Connect` and its `Service` impl.

The extra bounds on the inherent constructor methods make for better error diagnostics in generic code, where a failure to resolve the `MakeService` implementation would lack information on which trait bounds are not met.

This is, theoretically, a backward-incompatible change, and it's only an ergonomic improvement, so feel free to leave it for later if compatibility with the 0.1 release is important.