### PR TITLE
Add a shared error handle for background tasks.

### DIFF
--- a/src/client/background.rs
+++ b/src/client/background.rs
@@ -31,10 +31,7 @@ pub(super) struct Handle {
 
 impl Handle {
     pub(super) fn get_error(&self) -> Option<hyper::Error> {
-        self.error
-            .try_lock()
-            .ok()
-            .and_then(|mut err| err.take())
+        self.error.try_lock().ok().and_then(|mut err| err.take())
     }
 }
 

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -186,11 +186,10 @@ where
                 State::Handshake(ref mut fut) => {
                     let (sender, conn) = try_ready!(fut.poll().map_err(ConnectError::Handshake));
 
-                    self.exec
-                        .spawn(Background::new(conn))
-                        .map_err(|_| ConnectError::SpawnError)?;
+                    let (bg, handle) = Background::new(conn);
+                    self.exec.spawn(bg).map_err(|_| ConnectError::SpawnError)?;
 
-                    let connection = Connection::new(sender);
+                    let connection = Connection::new(sender, handle);
 
                     return Ok(Async::Ready(connection));
                 }


### PR DESCRIPTION
If the background tasks errors, it will set an error in a
shared handle, enabling the connection service to return
the error on `poll_ready`.