### PR TITLE
Implement `Clone` and `Debug` for `Client` manually.

### DIFF
--- a/src/client/background.rs
+++ b/src/client/background.rs
@@ -68,7 +68,7 @@ where
             // serverity to debug.
             debug!("error with hyper: {}", e);
             if let Ok(mut l) = self.handle.error.try_lock() {
-                *l = Some(e.into());
+                *l = Some(e);
             }
         })
     }

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -250,7 +250,7 @@ where
         }
     }
 
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             ConnectError::Connect(ref why) => Some(why),
             ConnectError::Handshake(ref why) => Some(why),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -43,15 +43,29 @@ use hyper::{
     client::{self, HttpConnector},
     Request, Response,
 };
+use std::fmt;
 use tower_service::Service;
 
 /// The client wrapp for `hyper::Client`
 ///
 /// The generics `C` and `B` are 1-1 with the generic
 /// types within `hyper::Client`.
-#[derive(Clone, Debug)]
 pub struct Client<C, B> {
     inner: hyper::Client<C, LiftBody<B>>,
+}
+
+impl<C, B> fmt::Debug for Client<C, B> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Client").field("inner", self.inner).finish()
+    }
+}
+
+impl<C, B> Clone for Client<C, B> {
+    fn clone(&self) -> Client<C, B> {
+        Client {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<B> Client<HttpConnector, B>

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -56,7 +56,9 @@ pub struct Client<C, B> {
 
 impl<C, B> fmt::Debug for Client<C, B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Client").field("inner", self.inner).finish()
+        f.debug_struct("Client")
+            .field("inner", &self.inner)
+            .finish()
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -70,6 +70,17 @@ impl<C, B> Clone for Client<C, B> {
     }
 }
 
+impl<B> Default for Client<HttpConnector, B>
+where
+    B: HttpBody + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<crate::Error>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<B> Client<HttpConnector, B>
 where
     B: HttpBody + Send + 'static,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,7 +15,7 @@ use tower_util::MakeService;
 pub use hyper::server::conn::Http;
 
 /// A stream mapping incoming IOs to new services.
-pub type Serve<E> = Box<Future<Item = (), Error = Error<E>> + Send + 'static>;
+pub type Serve<E> = Box<dyn Future<Item = (), Error = Error<E>> + Send + 'static>;
 
 /// Server implemenation for hyper
 #[derive(Debug)]

--- a/tests/connect.rs
+++ b/tests/connect.rs
@@ -72,7 +72,7 @@ struct Stream(TcpStream);
 impl Service<SocketAddr> for Http2 {
     type Response = Stream;
     type Error = std::io::Error;
-    type Future = Box<Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
+    type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         Ok(().into())


### PR DESCRIPTION
The existing `Derive`s require that `C` and `B` also implement debug/clone, but this is not necessary.